### PR TITLE
fix(drivers/thread): Use unscope function call

### DIFF
--- a/controllers/thread/response/json.go
+++ b/controllers/thread/response/json.go
@@ -40,8 +40,9 @@ func FromDomain(data *thread.Domain) Thread {
 	return Thread{
 		ID: data.ID,
 		Author: ThreadAuthor{
-			ID:       data.Author.ID,
-			Username: data.Author.Username,
+			ID:        data.Author.ID,
+			Username:  data.Author.Username,
+			DeletedAt: data.Author.DeletedAt,
 		},
 		Topic: ThreadTopic{
 			ID:           data.Topic.ID,

--- a/drivers/databases/thread/persistence.go
+++ b/drivers/databases/thread/persistence.go
@@ -15,7 +15,7 @@ type persistenceThreadRepository struct {
 
 func (rp *persistenceThreadRepository) CreateThread(data *thread.Domain, userId, topicId int) (thread.Domain, error) {
 	topic := topic.Topic{}
-	fetchTopic := rp.Conn.Take(&topic, topicId)
+	fetchTopic := rp.Conn.Unscoped().Take(&topic, topicId)
 	if fetchTopic.Error != nil {
 		return thread.Domain{}, fetchTopic.Error
 	}
@@ -92,7 +92,7 @@ func (rp *persistenceThreadRepository) GetThreadByAuthorID(userId, limit, offset
 
 func (rp *persistenceThreadRepository) GetThreadByTopicID(topicId, limit, offset int) ([]thread.Domain, error) {
 	threads := []Thread{}
-	fetchResult := rp.Conn.Preload("Author").Preload("Topic").Limit(limit).Offset(offset).Where("topic_id = ?", topicId).Find(&threads)
+	fetchResult := rp.Conn.Unscoped().Preload("Author").Preload("Topic").Limit(limit).Offset(offset).Where("topic_id = ?", topicId).Find(&threads)
 	if fetchResult.Error != nil {
 		return []thread.Domain{}, fetchResult.Error
 	}
@@ -119,7 +119,7 @@ func (rp *persistenceThreadRepository) GetThreadByTopicID(topicId, limit, offset
 
 func (rp *persistenceThreadRepository) GetThreadByKeyword(keyword string, limit, offset int) ([]thread.Domain, error) {
 	threads := []Thread{}
-	fetchResult := rp.Conn.Preload("Author").Preload("Topic").Limit(limit).Offset(offset).Where("title LIKE ?", keyword+"%").Find(&threads)
+	fetchResult := rp.Conn.Unscoped().Preload("Author").Preload("Topic").Limit(limit).Offset(offset).Where("title LIKE ?", keyword+"%").Find(&threads)
 	if fetchResult.Error != nil {
 		return []thread.Domain{}, fetchResult.Error
 	}


### PR DESCRIPTION
Thread should stay visible even if the author is banned