### PR TITLE
fix(ci): Use '.' instead of wildcard

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /app
 COPY go.sum go.mod ./
 RUN go mod download
 
-COPY * ./
+COPY . ./
 RUN go build -o /server ./app
 
 COPY ca.pem /


### PR DESCRIPTION
Prevent directory being flatten. Finally fix CI